### PR TITLE
Moved log messages to onResourceStart.

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -1,4 +1,6 @@
 -- Server
-
-logMessage("Persist-nv loading.")
-logMessage("Persist-nv loaded.")
+AddEventHandler('onResourceStart', function(resource)
+	if resource == 'persist-nv' then
+		logMessage("Persist-nv loaded.")
+	end
+end)


### PR DESCRIPTION
Updated main.lua to include an event handler for 'onResourceStart'. If the
resource starting is persist-nv, then print a message to the console.